### PR TITLE
Pip fix, version bump

### DIFF
--- a/group_vars/matrix_server/matrix.yml
+++ b/group_vars/matrix_server/matrix.yml
@@ -1,3 +1,3 @@
 ---
-matrix_version: "v0.18.4"
+matrix_version: "master"
 matrix_enable_registration: False

--- a/group_vars/riot.im_server/nginx.yml
+++ b/group_vars/riot.im_server/nginx.yml
@@ -10,4 +10,4 @@ nginx_sites:
      ssl_certificate: "/etc/letsencrypt/live/{{ riot_domain }}/cert.pem"
      ssl_certificate_key: "/etc/letsencrypt/live/{{ riot_domain }}/privkey.pem"
      ssl: "on"
-     root: "/var/www/html/vector-{{ riot_release }}"
+     root: "/var/www/html/riot-{{ riot_release }}"

--- a/group_vars/riot.im_server/riot.yml
+++ b/group_vars/riot.im_server/riot.yml
@@ -1,4 +1,4 @@
 ---
 riot_hs_url: "https://{{ matrix_domain }}:8448"
 riot_is_url: "https://{{ matrix_domain }}:8448"
-riot_release: "v0.9.1"
+riot_release: "v0.11.4"

--- a/playbooks/riot.yml
+++ b/playbooks/riot.yml
@@ -7,6 +7,14 @@
     - name: Install Nginx
       apt: name=nginx state=present update_cache=yes
 
+# Install pip
+- hosts: riot.im_server
+  become: yes
+  tags: certs
+  tasks:
+    - name: Install Pip
+      apt: name=python-pip state=present
+
 # Install setuptools for letsencrypt
 - hosts: riot.im_server
   become: yes
@@ -15,6 +23,7 @@
     - name: Install Setuptools
       pip:
         state: latest
+        executable: /usr/bin/pip
         name: "setuptools"
         extra_args: --process-dependency-links
 


### PR DESCRIPTION
Fixed missing pip package installation. Updated riot.im default version.
Changed vector.im naming to riot in nginx. Set default synapse version
to master.