### PR TITLE
fullchain.pem rather than cert.pem

### DIFF
--- a/group_vars/riot.im_server/nginx.yml
+++ b/group_vars/riot.im_server/nginx.yml
@@ -7,7 +7,7 @@ nginx_sites:
      file_name: riot
      listen: 443
      location1: {name: "/", try_files: "$uri $uri/ /index.html"}
-     ssl_certificate: "/etc/letsencrypt/live/{{ riot_domain }}/cert.pem"
+     ssl_certificate: "/etc/letsencrypt/live/{{ riot_domain }}/fullchain.pem"
      ssl_certificate_key: "/etc/letsencrypt/live/{{ riot_domain }}/privkey.pem"
      ssl: "on"
      root: "/var/www/html/riot-{{ riot_release }}"


### PR DESCRIPTION
Give nginx the fullchain certificate rather than just the simple certificate to avoid SEC_ERROR_UNKNOWN_ISSUER error (unknown certificate issuer) in Firefox (and most likely other browsers in general).